### PR TITLE
Only allow four styles max per page

### DIFF
--- a/src/diffenator/__init__.py
+++ b/src/diffenator/__init__.py
@@ -4,9 +4,14 @@ import os
 from ninja.ninja_syntax import Writer
 from diffenator.utils import dict_coords_to_string
 from fontTools.ttLib import TTFont
+import ninja
+from diffenator.utils import partition
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
+
+
+MAX_STYLES = 4
 
 
 def ninja_proof(
@@ -15,9 +20,27 @@ def ninja_proof(
     imgs: bool = False,
     filter_styles: bool = None,
 ):
+    if filter_styles:
+        _ninja_proof(fonts, out, imgs, filter_styles)
+        return
+    styles = styles_in_fonts(fonts)
+    partitioned = partition(styles, MAX_STYLES)
     if not os.path.exists(out):
         os.mkdir(out)
+    for p in partitioned:
+        filter_styles = "|".join(s[0] for s in p)
+        o = os.path.join(out, filter_styles.replace("|", "-"))
+        if not os.path.exists(o):
+            os.mkdir(o)
+        _ninja_proof(fonts, o, imgs, filter_styles)
 
+
+def _ninja_proof(
+    fonts: list[TTFont],
+    out: str = "out",
+    imgs: bool = False,
+    filter_styles: bool = None,
+):
     w = Writer(open(os.path.join("build.ninja"), "w", encoding="utf8"))
     w.comment("Rules")
     w.newline()
@@ -43,6 +66,7 @@ def ninja_proof(
         variables["filters"] = filter_styles
     w.build(out, "proofing", variables=variables)
     w.close()
+    ninja._program("ninja", [])
 
 
 def ninja_diff(
@@ -118,13 +142,21 @@ def ninja_diff(
     w.close()
 
 
-def _static_fullname(ttfont):
-    return (
-        f"{ttfont['name'].getBestFamilyName()} {ttfont['name'].getBestSubFamilyName()}"
-    )
+def styles_in_fonts(fonts):
+    styles = []
+    for font in fonts:
+        if "fvar" in font:
+            styles += styles_in_variable_font(font)
+        else:
+            styles.append(style_in_static_font(font))
+    return styles
 
 
-def _vf_fullnames(ttfont, filters=None):
+def style_in_static_font(ttfont):
+    return (ttfont['name'].getBestSubFamilyName(), {})
+
+
+def styles_in_variable_font(ttfont):
     assert "fvar" in ttfont
     res = []
     family_name = ttfont["name"].getBestFamilyName()
@@ -132,34 +164,13 @@ def _vf_fullnames(ttfont, filters=None):
     for inst in instances:
         name_id = inst.subfamilyNameID
         name = ttfont["name"].getName(name_id, 3, 1, 0x409).toUnicode()
-        if filters and name not in filters:
-            continue
-        res.append((f"{family_name} {name}", inst.coordinates))
+        res.append((name, inst.coordinates))
     return res
 
 
 def matcher(fonts_before, fonts_after, filters=None):
-    before = {}
-    after = {}
-    for font in fonts_before:
-        if "fvar" in font:
-            vf_names = _vf_fullnames(font, filters)
-            for n, coords in vf_names:
-                before[n] = (os.path.abspath(font.reader.file.name), coords)
-        else:
-            before[_static_fullname(font)] = (
-                os.path.abspath(font.reader.file.name),
-                {},
-            )
-
-    for font in fonts_after:
-        if "fvar" in font:
-            vf_names = _vf_fullnames(font, filters)
-            for n, coords in vf_names:
-                after[n] = (os.path.abspath(font.reader.file.name), coords)
-        else:
-            after[_static_fullname(font)] = (os.path.abspath(font.reader.file.name), {})
-
+    before = {k: v for k,v in styles_in_fonts(fonts_before)}
+    after = {k: v for k,v in styles_in_fonts(fonts_after)}
     shared = set(before.keys()) & set(after.keys())
     res = []
     for style in shared:

--- a/src/diffenator/__main__.py
+++ b/src/diffenator/__main__.py
@@ -56,7 +56,6 @@ def main(**kwargs):
         )
     else:
         raise NotImplementedError(f"{args.command} not supported")
-    ninja._program("ninja", [])
 
 
 if __name__ == "__main__":

--- a/src/diffenator/utils.py
+++ b/src/diffenator/utils.py
@@ -172,3 +172,8 @@ def font_family_name(ttFont, suffix=""):
         return f"{suffix} {familyname}"
     else:
         return familyname
+
+
+def partition(items, size):
+    """partition([1,2,3,4,5,6], 2) --> [[1,2],[3,4],[5,6]]"""
+    return [items[i : i + size] for i in range(0, len(items), size)]

--- a/tests/data/ninja_files/diff-filter-styles.txt
+++ b/tests/data/ninja_files/diff-filter-styles.txt
@@ -19,24 +19,24 @@ build out/diffbrowsers: diffbrowsers
       .*/tests/data/MavenPro\[wght\].subset.mod.ttf
   out = out/diffbrowsers
   filters = Medium|ExtraBold
-build out/Maven-Pro-Bold: diffenator-inst
+build out/Bold: diffenator-inst
   font_before = \$
       .*/tests/data/MavenPro\[wght\].subset.ttf
   font_after = \$
       .*/tests/data/MavenPro\[wght\].subset.mod.ttf
-  out = Maven-Pro-Bold
+  out = Bold
   coords = wght=700.0
-build out/Maven-Pro-ExtraBold: diffenator-inst
+build out/ExtraBold: diffenator-inst
   font_before = \$
       .*/tests/data/MavenPro\[wght\].subset.ttf
   font_after = \$
       .*/tests/data/MavenPro\[wght\].subset.mod.ttf
-  out = Maven-Pro-ExtraBold
+  out = ExtraBold
   coords = wght=800.0
 build out/Maven-Pro-Medium: diffenator-inst
   font_before = \$
       .*/tests/data/MavenPro\[wght\].subset.ttf
   font_after = \$
       .*/tests/data/MavenPro\[wght\].subset.mod.ttf
-  out = Maven-Pro-Medium
+  out = Medium
   coords = wght=500.0

--- a/tests/data/ninja_files/diff-imgs.txt
+++ b/tests/data/ninja_files/diff-imgs.txt
@@ -18,45 +18,45 @@ build out/diffbrowsers: diffbrowsers
   fonts_after = \$
       .*/tests/data/MavenPro\[wght\].subset.mod.ttf
   out = out/diffbrowsers
-build out/Maven-Pro-Black: diffenator-inst
+build out/Black: diffenator-inst
   font_before = \$
       .*/tests/data/MavenPro\[wght\].subset.ttf
   font_after = \$
       .*/tests/data/MavenPro\[wght\].subset.mod.ttf
-  out = Maven-Pro-Black
+  out = Black
   coords = wght=900.0
-build out/Maven-Pro-Bold: diffenator-inst
+build out/Bold: diffenator-inst
   font_before = \$
       .*/tests/data/MavenPro\[wght\].subset.ttf
   font_after = \$
       .*/tests/data/MavenPro\[wght\].subset.mod.ttf
-  out = Maven-Pro-Bold
+  out = Bold
   coords = wght=700.0
-build out/Maven-Pro-ExtraBold: diffenator-inst
+build out/ExtraBold: diffenator-inst
   font_before = \$
       .*/tests/data/MavenPro\[wght\].subset.ttf
   font_after = \$
       .*/tests/data/MavenPro\[wght\].subset.mod.ttf
-  out = Maven-Pro-ExtraBold
+  out = ExtraBold
   coords = wght=800.0
-build out/Maven-Pro-Medium: diffenator-inst
+build out/Medium: diffenator-inst
   font_before = \$
       .*/tests/data/MavenPro\[wght\].subset.ttf
   font_after = \$
       .*/tests/data/MavenPro\[wght\].subset.mod.ttf
-  out = Maven-Pro-Medium
+  out = Medium
   coords = wght=500.0
-build out/Maven-Pro-Regular: diffenator-inst
+build out/Regular: diffenator-inst
   font_before = \$
       .*/tests/data/MavenPro\[wght\].subset.ttf
   font_after = \$
       .*/tests/data/MavenPro\[wght\].subset.mod.ttf
-  out = Maven-Pro-Regular
+  out = Regular
   coords = wght=400.0
-build out/Maven-Pro-SemiBold: diffenator-inst
+build out/SemiBold: diffenator-inst
   font_before = \$
       .*/tests/data/MavenPro\[wght\].subset.ttf
   font_after = \$
       .*/tests/data/MavenPro\[wght\].subset.mod.ttf
-  out = Maven-Pro-SemiBold
+  out = SemiBold
   coords = wght=600.0

--- a/tests/data/ninja_files/diff-standard.txt
+++ b/tests/data/ninja_files/diff-standard.txt
@@ -17,45 +17,45 @@ build out/diffbrowsers: diffbrowsers
   fonts_after = \$
       .*/tests/data/MavenPro\[wght\].subset.mod.ttf
   out = out/diffbrowsers
-build out/Maven-Pro-Black: diffenator-inst
+build out/Black: diffenator-inst
   font_before = \$
       .*/tests/data/MavenPro\[wght\].subset.ttf
   font_after = \$
       .*/tests/data/MavenPro\[wght\].subset.mod.ttf
-  out = Maven-Pro-Black
+  out = Black
   coords = wght=900.0
-build out/Maven-Pro-Bold: diffenator-inst
+build out/Bold: diffenator-inst
   font_before = \$
       .*/tests/data/MavenPro\[wght\].subset.ttf
   font_after = \$
       .*/tests/data/MavenPro\[wght\].subset.mod.ttf
-  out = Maven-Pro-Bold
+  out = Bold
   coords = wght=700.0
-build out/Maven-Pro-ExtraBold: diffenator-inst
+build out/ExtraBold: diffenator-inst
   font_before = \$
       .*/tests/data/MavenPro\[wght\].subset.ttf
   font_after = \$
       .*/tests/data/MavenPro\[wght\].subset.mod.ttf
-  out = Maven-Pro-ExtraBold
+  out = ExtraBold
   coords = wght=800.0
-build out/Maven-Pro-Medium: diffenator-inst
+build out/Medium: diffenator-inst
   font_before = \$
       .*/tests/data/MavenPro\[wght\].subset.ttf
   font_after = \$
       .*/tests/data/MavenPro\[wght\].subset.mod.ttf
-  out = Maven-Pro-Medium
+  out = Medium
   coords = wght=500.0
-build out/Maven-Pro-Regular: diffenator-inst
+build out/Regular: diffenator-inst
   font_before = \$
       .*/tests/data/MavenPro\[wght\].subset.ttf
   font_after = \$
       .*/tests/data/MavenPro\[wght\].subset.mod.ttf
-  out = Maven-Pro-Regular
+  out = Regular
   coords = wght=400.0
-build out/Maven-Pro-SemiBold: diffenator-inst
+build out/SemiBold: diffenator-inst
   font_before = \$
       .*/tests/data/MavenPro\[wght\].subset.ttf
   font_after = \$
       .*/tests/data/MavenPro\[wght\].subset.mod.ttf
-  out = Maven-Pro-SemiBold
+  out = SemiBold
   coords = wght=600.0

--- a/tests/test_ninja.py
+++ b/tests/test_ninja.py
@@ -38,12 +38,14 @@ import re
     ]
 )
 def test_run_ninja_diff(kwargs, expected_fp):
-    from diffenator import ninja_diff
+    from diffenator import _ninja_diff
 
-    ninja_diff(**kwargs)
+    _ninja_diff(**kwargs)
 
     with open(expected_fp) as expected, open("build.ninja") as current:
-        assert re.match(expected.read(), current.read())
+        exp = expected.read()
+        cur = current.read()
+        assert re.match(exp, cur)
 
 
 @pytest.mark.parametrize(
@@ -76,8 +78,10 @@ def test_run_ninja_diff(kwargs, expected_fp):
     ]
 )
 def test_run_ninja_proof(kwargs, expected_fp):
-    from diffenator import ninja_proof
+    from diffenator import _ninja_proof
 
-    ninja_proof(**kwargs)
+    _ninja_proof(**kwargs)
     with open(expected_fp) as expected, open("build.ninja") as current:
-        assert re.match(expected.read(), current.read())
+        exp = expected.read()
+        cur = current.read()
+        assert re.match(exp, cur)


### PR DESCRIPTION
In Diffbrowsers, I only allowed four font styles per page since browserstack put restrictions on image height. Even though we can generate images which are much higher, it's still worthwhile only allowing a max of four styles per page. Generating huge images can cause github runners to crash.